### PR TITLE
Remove img tag when the speaker doesn't have a image

### DIFF
--- a/src/partials/section/schedule.html.eco
+++ b/src/partials/section/schedule.html.eco
@@ -20,7 +20,11 @@
             <% if slot.presentation: %>
               <tr>
                 <td class="schedule-time"><%= slot.presentation.time %></td>
-                <td class="schedule-slot"><span class="speaker-photo"><img class="photo" src="<%= slot.photo %>" alt="<%= slot.name %>" /></span> <%= slot.presentation.title %> <span class="speakers-company"><%= slot.company %></span></td>
+                <td class="schedule-slot">
+                <% if slot.photo: %>
+                  <span class="speaker-photo"><img class="photo" src="<%= slot.photo %>" alt="<%= slot.name %>" /></span>
+                <% end %>
+                <%= slot.presentation.title %> <span class="speakers-company"><%= slot.company %></span></td>
                 <td class="schedule-description"><%= slot.presentation.description %></td>
               </tr>
             <% else: %>

--- a/src/partials/section/speakers.html.eco
+++ b/src/partials/section/speakers.html.eco
@@ -9,7 +9,9 @@
     <% for speaker in @schedule: %>
       <% if speaker.presentation: %>
         <li class="speakers-item" itemprop="performer" itemscope itemtype="http://schema.org/Person">
-          <span class="speaker-photo"><img class="photo" src="<%= speaker.photo %>" alt="<%= speaker.name %>" itemprop="image" /></span>
+          <% if speaker.photo: %>
+            <span class="speaker-photo"><img class="photo" src="<%= speaker.photo %>" alt="<%= speaker.name %>" itemprop="image" /></span>
+          <% end %>
 
           <h3 class="speech-title">
             <% if speaker.presentation.time: %>


### PR DESCRIPTION
Quanto o palestrante não tinha uma imagem, ficava apenas uma borda vazia no Schedule e
no Schedule.

Nem sempre uma imagem é necessária, exemplo disso é uma mesa redonda onde temos
vários "palestrantes"
