### PR TITLE
Install docpad in devDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,3 @@ node_js:
   - 0.8
   - 0.9
   - 0.10
-before_script:
-  - docpad generate

--- a/README-pt.md
+++ b/README-pt.md
@@ -52,9 +52,11 @@ Pré-requisitos: Instale o [Git](http://git-scm.com/downloads) e o [NodeJS](http
 
 		[sudo] npm install
 
+PS: Talvez você precise usar o `sudo`
+
 3. E finalmente rode:
 
-		docpad run
+		npm start
 
 Agora você irá ver o site rodando em `localhost:9778` :D
 

--- a/package.json
+++ b/package.json
@@ -11,8 +11,9 @@
     "node": ">0.8.x",
     "npm": "1.1.x"
   },
-  "scripts" : {
-    "preinstall": "sudo npm install -fg docpad@6.30.x"
+  "scripts": {
+    "test": "docpad generate",
+    "start": "docpad run"
   },
   "dependencies": {
     "docpad-plugin-eco": "2.0.2",
@@ -20,5 +21,8 @@
     "docpad-plugin-partials": "2.6.1",
     "docpad-plugin-less": "2.1.3",
     "docpad-plugin-ghpages": "2.0.2"
+  },
+  "devDependencies": {
+    "docpad": "6.30.x"
   }
 }


### PR DESCRIPTION
Funcionando lindamente agora. 
PS: Na minha maquina testei apenas no NodeJS 0.10.4 no Ubuntu e no Max OS X

Para testar o uso correto desinstale o docpad global e siga os passos
2 - Clone o repo, de um fetch no branch `scripts`
3 - npm install
4 - npm start
Acesse localhost:9778 e boa sorte. :+1: 

Os builds no travis funcionou ok tbm. https://travis-ci.org/felquis/conf-boilerplate/builds/6397485

Print do meu terminal, pra ver como funcionou por aqui, repare que no final eu interrompo o script do DocPad e digito docpad, e o comando é desconhecido.

![Screenshot from 2013-04-16 19:26:45](https://f.cloud.github.com/assets/736728/388865/4ff264d2-a6e7-11e2-8498-dbd4910bd4c4.png)

Testa ai e me diga :dancer: 
