### PR TITLE
[add] Speaker URL

### DIFF
--- a/docpad.coffee
+++ b/docpad.coffee
@@ -54,7 +54,9 @@ module.exports =
       photo: "http://f.cl.ly/items/2A3p1N0C3c0n3N3R1w2B/speaker.jpg"
       bio: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
       company: "Linux Foundation"
-      twitter: "linus"
+      link:
+        href: "http://twitter.com/linus",
+        text: "@linus"
       presentation:
         title: "Digging into a Linux Kernel"
         description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
@@ -64,7 +66,9 @@ module.exports =
       photo: "http://f.cl.ly/items/2A3p1N0C3c0n3N3R1w2B/speaker.jpg"
       bio: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
       company: "Microsoft"
-      twitter: "billy95"
+      link:
+        href: "http://github.com/billy95",
+        text: "Github billy95"
       presentation:
         title: "Introducing Windows 12"
         description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
@@ -77,7 +81,9 @@ module.exports =
       photo: "http://f.cl.ly/items/2A3p1N0C3c0n3N3R1w2B/speaker.jpg"
       bio: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
       company: "Delta Command"
-      twitter: "littlechuck"
+      link:
+        href: "http://twitter.com/littlechuck",
+        text: "@littlechuck"
       presentation:
         title: "How to kill a elephant with one finger"
         description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
@@ -87,7 +93,9 @@ module.exports =
       photo: "http://f.cl.ly/items/2A3p1N0C3c0n3N3R1w2B/speaker.jpg"
       bio: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
       company: "Apple, Inc."
-      twitter: "stevie"
+      link:
+        href: "http://twitter.com/stevie",
+        text: "@stevie"
       presentation:
         title: "Presenting iPad"
         description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
@@ -100,7 +108,9 @@ module.exports =
       photo: "http://f.cl.ly/items/2A3p1N0C3c0n3N3R1w2B/speaker.jpg"
       bio: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
       company: "Facebook"
-      twitter: "zuck"
+      link:
+        href: "http://twitter.com/zuck",
+        text: "@zuck"
       presentation:
         title: "Revealing Facebook Secrets"
         description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
@@ -110,7 +120,9 @@ module.exports =
       photo: "http://f.cl.ly/items/2A3p1N0C3c0n3N3R1w2B/speaker.jpg"
       bio: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"
       company: "Apple, Inc."
-      twitter: "woz"
+      link:
+        href: "http://twitter.com/woz",
+        text: "@woz"
       presentation:
         title: "Why do I prefer Android over iPhone"
         description: "Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo"

--- a/src/partials/section/schedule.html.eco
+++ b/src/partials/section/schedule.html.eco
@@ -22,7 +22,7 @@ tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam.</p>
                 <img class="photo" src="<%= slot.photo %>" alt="<%= slot.name %>">
               </span>
             <% end %>
-            <%= slot.presentation.title %> 
+            <%= slot.presentation.title %>
               <span class="speakers-company"><%= slot.company %></span>
             </td>
             <td class="schedule-description"><%= slot.presentation.description %></td>

--- a/src/partials/section/speakers.html.eco
+++ b/src/partials/section/speakers.html.eco
@@ -17,7 +17,7 @@
           <span> <%= speaker.presentation.title %></span>
       </h3>
 
-      <h3 class="speakers-name"><%= speaker.name %> <a href="http://www.twitter.com/<%= speaker.twitter %>" title="Twitter @<%= speaker.twitter %>">@<%= speaker.twitter %></a></h3>
+      <h3 class="speakers-name"><%= speaker.name %> <% if speaker.link: %><a href="<%= speaker.link.href %>" title="<%= speaker.link.text %>"><%= speaker.link.text %></a><% end %></h3>
       <p class="speakers-bio"><%= speaker.bio %></p>
     </li>
   <% end %>


### PR DESCRIPTION
Vi um "erro" [neste site](http://yodojo.github.io/yoLab/#speakers) feito com Conf, na sessão de Speaker, o speaker não tem Twitter mas mesmo assim ele mostrar um @ com link para o twitter.

Então, filosofei que um speaker pode querer colocar qualquer tipo de URL como github, site pessoal, linkedin ou URL nenhuma.  Por isso fiz essa pequena alteração.
