### PR TITLE
Corrigindo Localização no Mapa

### DIFF
--- a/src/partials/section/location.html.eco
+++ b/src/partials/section/location.html.eco
@@ -6,4 +6,4 @@
   <span itemprop="addressRegion"> <%= @conf.state %></span>
 </p>
 
-<div id="map-canvas" class="location-area" data-address="<%= @conf.address %>"></div>
+<div id="map-canvas" class="location-area" data-address="<%= @conf.address %>, <%= @conf.city %> - <%= @conf.state %>"></div>


### PR DESCRIPTION
Aconteceu uma coisa no site do FrontIn Cuiabá. O endereço do local dava em outra cidade, corrige da mesma forma que está no commit. (: uma outra alternativa é colocar o LatLng.