### PR TITLE
Fix errors "missing script: ./cyclic.js" and "No compatible version found: eco@>=1.1.0 <1.2.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "watch": "docpad run"
   },
   "dependencies": {
-    "docpad": "6.30.x",
-    "docpad-plugin-eco": "2.0.2",
+    "docpad": "6.78.x",
+    "docpad-plugin-eco": "2.1.0",
     "docpad-plugin-marked": "2.1.1",
     "docpad-plugin-partials": "2.6.1",
     "docpad-plugin-less": "2.1.3",


### PR DESCRIPTION
I've fixed these errors. I believe others can be getting the same messages as well.

```shell
(...)
npm ERR! Darwin 14.3.0
npm ERR! argv "node" "/usr/local/bin/npm" "run-script" "./cyclic.js"
npm ERR! node v0.12.1
npm ERR! npm  v2.5.1

npm ERR! missing script: ./cyclic.js
npm ERR! 
npm ERR! If you need help, you may report this error at:
npm ERR!     <http://github.com/npm/npm/issues>

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/jweber/dev/projects/jsday/node_modules/docpad/node_modules/cson/node_modules/js2coffee/npm-debug.log
npm ERR! Darwin 14.3.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.1
npm ERR! npm  v2.5.1
npm ERR! code ELIFECYCLE
(...)
```

And...

```shell 
(...)
nm ERR! Darwin 14.3.0
npm ERR! argv "node" "/usr/local/bin/npm" "install"
npm ERR! node v0.12.1
npm ERR! npm  v2.5.1
npm ERR! code ETARGET

npm ERR! notarget No compatible version found: eco@'>=1.1.0 <1.2.0'
npm ERR! notarget Valid install targets:
npm ERR! notarget ["1.0.0","1.0.1","1.0.2","1.0.3","1.1.0-rc-1","1.1.0-rc-2","1.1.0-rc-3"]
npm ERR! notarget 
npm ERR! notarget This is most likely not a problem with npm itself.
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.
(..)
```

