### PR TITLE
Fix speaker's link

### DIFF
--- a/src/partials/section/speakers.html
+++ b/src/partials/section/speakers.html
@@ -19,7 +19,14 @@
             <span> {{ this.presentation.title }}</span>
         </h3>
 
-        <h3 class="speakers-name">{{ this.name }} {{#if this.link }} title="{{ this.link.text }}">{{ this.link.text }}</a>{{/if}}</h3>
+        <h3 class="speakers-name">
+          {{ this.name }}
+          {{#if this.link }}
+            <a href="{{ this.link.href }}" title="{{ this.link.text }}">
+              {{ this.link.text }}
+            </a>
+          {{/if}}
+        </h3>
         <p class="speakers-bio">{{ this.bio }}</p>
       </li>
     {{/if}}


### PR DESCRIPTION
In [migration to Metalsmith](https://github.com/braziljs/conf-boilerplate/issues/109), the markup for speaker's link was incomplete:

**Before:**
![selection_163](https://cloud.githubusercontent.com/assets/487669/7244125/199b12a4-e7ad-11e4-92bf-fbeba1c87940.png)

---

**Now:**
![selection_164](https://cloud.githubusercontent.com/assets/487669/7244127/1dadd3f4-e7ad-11e4-8e5e-991a0a6519ba.png)