### PR TITLE
CSS class "sponsor-logo" prevents images to be loaded when using AdBlock

### DIFF
--- a/src/partials/section/sponsors.html.eco
+++ b/src/partials/section/sponsors.html.eco
@@ -3,7 +3,7 @@
 
 <% for sponsor in @sponsors: %>
   <li class="sponsor-item" itemscope itemtype="http://schema.org/Organization">
-    <a href="<%= sponsor.url %>" class="sponsor-logo sponsor--link" itemprop="url">
+    <a href="<%= sponsor.url %>" class="sponsor--link" itemprop="url">
       <img src="<%= sponsor.logo %>" alt="<%= sponsor.name %>" class="photo" itemprop="image">
     </a>
   </li>


### PR DESCRIPTION
I have removed the class because it's not used by any stylesheets at all in the application. From my point of view, the styling flexibility it gives is not worth if compared to the impact of unloaded *sponsor* ($$) images for many users that use this extension nowadays, mostly tech users (the main target for this kind of app). Also the DOM element has another class (sponsor--link) which can then be used for additional styling.